### PR TITLE
Configure fails due to incompatible pointer type with POSIX's execvp(2).

### DIFF
--- a/src/imake/imake.c
+++ b/src/imake/imake.c
@@ -769,7 +769,7 @@ optional_include(FILE *inFile, const char *defsym, const char *fname)
 }
 
 void
-doit(FILE *outfd, const char *cmd, const char **argv)
+doit(FILE *outfd, const char *cmd, const char *const *argv)
 {
 	int		pid;
 	waitType	status;


### PR DESCRIPTION
Using gcc-4.8.5 and glibc-headers-2.17-157.el7_3.1 under RHEL7, conflict
with:
=====
src/imake/imake.c: In function 'doit':
src/imake/imake.c:806:3: warning: passing argument 2 of 'execvp' from incompatib
le pointer type [enabled by default]
   execvp(cmd, argv);
=====